### PR TITLE
Adds a missing key in the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const todoHandler = {
     ADD: (state: Todo[], newTodo: Todo) => [...state, newItem],
     TOGGLE: (state: Todo[], index: number) => [
         ...state.slice(0, index),
-        { state[index], completed: !state[index].completed },
+        { task: state[index].task, completed: !state[index].completed },
         ...state.slice(index + 1)
     ]
 };


### PR DESCRIPTION
 Add missing key in state object of the usage example in the README.

A minor thing which is written correctly in the Simple TODO example. However, since this library is about type safety it's important to have this right inside the README.